### PR TITLE
[codex] Improve chat limits, errors, and loading UI

### DIFF
--- a/convex/limiter.ts
+++ b/convex/limiter.ts
@@ -47,19 +47,19 @@ export const rateLimiter = new RateLimiter(components.rateLimiter, {
 
   anonymousMessages: {
     kind: "fixed window",
-    rate: 5, // 5 messages per day
+    rate: 20, // 20 messages per day
     period: 24 * HOUR,
   },
 
   anonymousThreads: {
     kind: "fixed window",
-    rate: 2, // 2 threads per day
+    rate: 5, // 5 threads per day
     period: 24 * HOUR,
   },
 
   anonymousAiRequests: {
     kind: "fixed window",
-    rate: 5, // 5 AI requests per day
+    rate: 20, // 20 AI requests per day
     period: 24 * HOUR,
   },
 })

--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -95,6 +95,7 @@ export default function Layout() {
         headerStyle: {
           backgroundColor: theme.colors.background,
         },
+        headerTintColor: theme.colors.palette.primary500,
         headerRight: () => (
           <CreateThreadIcon
             isCreatingThread={isCreatingThread}

--- a/src/app/(home)/_layout.tsx
+++ b/src/app/(home)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react"
-import { ActivityIndicator } from "react-native"
+import { ActivityIndicator, Alert } from "react-native"
 import { useRouter } from "expo-router"
 import { useMutation, useQuery, useConvexAuth } from "convex/react"
 import { Drawer } from "expo-router/drawer"
@@ -11,6 +11,7 @@ import { PressableIcon } from "@/components/Icon"
 import { useAppTheme } from "@/theme/context"
 import { spacing } from "@/theme/spacing"
 import { getAnonymousUserId } from "@/utils/anonymousUser"
+import { getChatErrorMessage } from "@/utils/chatErrors"
 import { reportCrash, ErrorType } from "@/utils/crashReporting"
 
 interface CreateThreadIconProps {
@@ -60,7 +61,6 @@ export default function Layout() {
 
   const router = useRouter()
 
-
   const handleThreadPress = useCallback(
     (navigation: any) => (threadId: string) => {
       router.push({ pathname: "/(home)/[threadId]", params: { threadId } })
@@ -82,6 +82,7 @@ export default function Layout() {
     } catch (error) {
       console.error("Failed to create thread:", error)
       reportCrash(error as Error, ErrorType.HANDLED)
+      Alert.alert("Unable to create chat", getChatErrorMessage(error, "Please try again."))
     } finally {
       setIsCreatingThread(false)
     }

--- a/src/app/(home)/index.tsx
+++ b/src/app/(home)/index.tsx
@@ -1,7 +1,14 @@
-import { Image, ImageStyle, TextStyle, View, ViewStyle, Pressable, ActivityIndicator } from "react-native"
-import { AuthView } from "@clerk/expo/native"
-import { useAuth, useUser, useClerk, useUserProfileModal } from "@clerk/expo"
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  ImageStyle,
+  TextStyle,
+  View,
+  ViewStyle,
+} from "react-native"
 import { useRouter } from "expo-router"
+import { useUser } from "@clerk/expo"
 import {
   Authenticated,
   Unauthenticated,
@@ -20,6 +27,7 @@ import { useAppTheme } from "@/theme/context"
 import { $styles } from "@/theme/styles"
 import type { ThemedStyle } from "@/theme/types"
 import { getAnonymousUserId } from "@/utils/anonymousUser"
+import { getChatErrorMessage } from "@/utils/chatErrors"
 import { useSafeAreaInsetsStyle } from "@/utils/useSafeAreaInsetsStyle"
 
 const welcomeLogo = require("@assets/images/logo.png")
@@ -34,9 +42,12 @@ export default function WelcomeScreen() {
 
   const handleNewChat = () => {
     const threadArgs = isAuthenticated ? {} : { anonymousUserId: getAnonymousUserId() }
-    createThread(threadArgs).then((threadId) =>
-      router.push({ pathname: "/(home)/[threadId]", params: { threadId } }),
-    )
+    createThread(threadArgs)
+      .then((threadId) => router.push({ pathname: "/(home)/[threadId]", params: { threadId } }))
+      .catch((error) => {
+        console.error("Failed to create thread:", error)
+        Alert.alert("Unable to create chat", getChatErrorMessage(error, "Please try again."))
+      })
   }
 
   const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
@@ -67,7 +78,7 @@ export default function WelcomeScreen() {
         <Unauthenticated>
           <Text preset="subheading" text="Try PlatoChat" style={themed($anonymousHeading)} />
           <Button
-            text="Start Anonymous Chat (5 messages/day)"
+            text="Start Anonymous Chat (20 messages/day)"
             onPress={handleNewChat}
             style={themed($anonymousButton)}
           />
@@ -142,10 +153,4 @@ const $anonymousButton: ThemedStyle<ViewStyle> = ({ spacing }) => ({
 const $anonymousSubtext: ThemedStyle<TextStyle> = ({ spacing }) => ({
   textAlign: "center",
   marginBottom: spacing.sm,
-})
-
-const $linkContainer: ThemedStyle<ViewStyle> = ({ spacing }) => ({
-  flexDirection: "row",
-  gap: spacing.md,
-  justifyContent: "center",
 })

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
+  ActivityIndicator,
   Alert,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -158,23 +159,60 @@ const MessageItem: React.FC<MessageItemProps> = ({
   const [visibleText] = useSmoothText(contentText)
 
   const isUser = role === "user"
+  const displayName = isUser ? "You" : role === "assistant" ? "Plato" : role
   const $baseStyle: ViewStyle = {
-    padding: theme.spacing.md,
-    marginVertical: theme.spacing.xxs,
+    padding: theme.spacing.sm,
+    marginVertical: theme.spacing.xs,
     borderRadius: theme.spacing.md,
-    maxWidth: "80%",
+    maxWidth: isSmall ? "88%" : "76%",
+    minHeight: undefined,
+    borderWidth: 1,
   }
   const $userStyle: ViewStyle = {
     alignSelf: "flex-end",
-    backgroundColor: theme.colors.palette.primary400,
+    backgroundColor: theme.colors.palette.primary500,
+    borderColor: theme.colors.palette.primary600,
+    borderBottomRightRadius: theme.spacing.xxs,
     marginRight: theme.spacing.md,
   }
   const $assistantStyle: ViewStyle = {
     alignSelf: "flex-start",
-    backgroundColor: theme.colors.palette.neutral400,
+    backgroundColor: theme.colors.palette.neutral100,
+    borderColor: theme.colors.palette.neutral300,
+    borderBottomLeftRadius: theme.spacing.xxs,
     marginLeft: theme.spacing.md,
   }
   const $messageStyle = { ...$baseStyle, ...(isUser ? $userStyle : $assistantStyle) }
+  const $messageHeader: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: theme.spacing.sm,
+  }
+  const $messageHeaderLeft: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.xs,
+  }
+  const $avatarDot: ViewStyle = {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: isUser ? theme.colors.palette.neutral100 : theme.colors.palette.primary500,
+  }
+  const $headingText: TextStyle = {
+    color: isUser ? theme.colors.palette.neutral100 : theme.colors.text,
+    letterSpacing: 0.2,
+  }
+  const $timestampText: TextStyle = {
+    color: isUser ? theme.colors.palette.primary100 : theme.colors.textDim,
+  }
+  const $userContentText: TextStyle = {
+    color: theme.colors.palette.neutral100,
+  }
+  const $emptyMessageText: TextStyle = {
+    color: isUser ? theme.colors.palette.primary100 : theme.colors.textDim,
+  }
   // Prefer stable database id for interactions; fall back to UI key if missing
   const messageId = response._id ?? response.key
 
@@ -202,18 +240,33 @@ const MessageItem: React.FC<MessageItemProps> = ({
 
   const { githubTheme } = themes
 
+  const headingComponent = (
+    <View style={$messageHeader}>
+      <View style={$messageHeaderLeft}>
+        <View style={$avatarDot} />
+        <Text text={displayName} weight="bold" size="xxs" style={$headingText} />
+      </View>
+      {!!timestamp && <Text text={timestamp} size="xxs" style={$timestampText} />}
+    </View>
+  )
+
+  const contentComponent = isUser ? (
+    <Text
+      text={visibleText || "(No content)"}
+      style={visibleText ? $userContentText : $emptyMessageText}
+    />
+  ) : (
+    <Markdown
+      markdown={visibleText || "(No content)"}
+      theme={githubTheme}
+      onCodeCopy={(code) => clipboard.setString(code)}
+    />
+  )
+
   const messageCard = (
     <Card
-      heading={role.charAt(0).toUpperCase() + role.slice(1)}
-      ContentComponent={
-        <Markdown
-          markdown={visibleText || "(No content)"}
-          theme={githubTheme}
-          onCodeCopy={(code) => clipboard.setString(code)}
-        ></Markdown>
-      }
-      footer={timestamp}
-      FooterTextProps={{ style: { color: theme.colors.textDim } }}
+      HeadingComponent={headingComponent}
+      ContentComponent={contentComponent}
       style={$messageStyle}
     />
   )
@@ -275,6 +328,24 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
   const $buttonRow: ViewStyle = {
     flexDirection: "row",
     gap: theme.spacing.md,
+  }
+  const $scrollContent: ViewStyle = {
+    paddingTop: theme.spacing.lg,
+    paddingBottom: theme.spacing.xl,
+  }
+  const $emptyCard: ViewStyle = {
+    marginHorizontal: theme.spacing.lg,
+    padding: theme.spacing.lg,
+    borderRadius: theme.spacing.lg,
+    backgroundColor: theme.colors.palette.neutral100,
+    borderWidth: 1,
+    borderColor: theme.colors.palette.neutral300,
+  }
+  const $emptyHeading: TextStyle = { textAlign: "center" }
+  const $emptyText: TextStyle = {
+    textAlign: "center",
+    color: theme.colors.textDim,
+    marginTop: theme.spacing.xs,
   }
 
   // Mutation handlers
@@ -447,7 +518,14 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
   if (serverMessages.length === 0) {
     return (
       <View style={$centerContent}>
-        <Text preset="subheading" tx="chat:noMessages" />
+        <View style={$emptyCard}>
+          <Text preset="subheading" tx="chat:noMessages" style={$emptyHeading} />
+          <Text
+            preset="formHelper"
+            text="Ask a question, draft a message, or paste something you want help with."
+            style={$emptyText}
+          />
+        </View>
       </View>
     )
   }
@@ -460,11 +538,14 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
 
   const $typingBubbleStyle: ViewStyle = {
     alignSelf: "flex-start",
-    backgroundColor: theme.colors.palette.neutral400,
+    backgroundColor: theme.colors.palette.neutral100,
+    borderColor: theme.colors.palette.neutral300,
+    borderWidth: 1,
     marginLeft: theme.spacing.md,
     padding: theme.spacing.md,
     marginVertical: theme.spacing.xxs,
     borderRadius: theme.spacing.md,
+    borderBottomLeftRadius: theme.spacing.xxs,
     maxWidth: "80%",
   }
 
@@ -492,7 +573,11 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
         onScroll={handleScroll}
         onContentSizeChange={handleContentSizeChange}
         scrollEventThrottle={100}
+        contentContainerStyle={$scrollContent}
       >
+        {isLoadingMore && (
+          <ActivityIndicator color={theme.colors.tint} style={{ marginBottom: theme.spacing.sm }} />
+        )}
         {uiMessages.map((item, index) => {
           const isLastUserMessage =
             item.role === "user" &&

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -18,6 +18,7 @@ import { api } from "convex/_generated/api"
 
 import { useAppTheme } from "@/theme/context"
 import { getAnonymousUserId } from "@/utils/anonymousUser"
+import { getChatErrorMessage } from "@/utils/chatErrors"
 import clipboard from "@/utils/clipboard"
 import { useResponsive } from "@/utils/useResponsive"
 
@@ -293,10 +294,7 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
         })
       } catch (error) {
         console.error("Failed to edit message:", error)
-        Alert.alert(
-          "Edit Failed",
-          error instanceof Error ? error.message : "Failed to edit message",
-        )
+        Alert.alert("Edit Failed", getChatErrorMessage(error, "Failed to edit message"))
       }
     },
     [editMessage, threadId, isAuthenticated],
@@ -314,10 +312,7 @@ export const MessageList: React.FC<Props> = ({ threadId, pageSize = 10 }) => {
         })
       } catch (error) {
         console.error("Failed to retry message:", error)
-        Alert.alert(
-          "Retry Failed",
-          error instanceof Error ? error.message : "Failed to retry message",
-        )
+        Alert.alert("Retry Failed", getChatErrorMessage(error, "Failed to retry message"))
       }
     },
     [retryMessage, threadId, isAuthenticated],

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -94,8 +94,16 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
     setThreadModelOverride(threadId, modelId)
   }
 
+  const handleMessageChange = (nextMessage: string) => {
+    setMessage(nextMessage)
+    if (errorMessage) {
+      setErrorMessage(null)
+    }
+  }
+
   const handleSendMessage = async () => {
-    if (!message.trim()) return
+    const trimmedMessage = message.trim()
+    if (!trimmedMessage) return
 
     setIsLoading(true)
     setErrorMessage(null)
@@ -104,7 +112,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
       const anonymousUserId = isAuthenticated ? undefined : getAnonymousUserId()
       await sendMessage({
         threadId,
-        prompt: message,
+        prompt: trimmedMessage,
         modelId: selectedModelId,
         anonymousUserId,
       })
@@ -135,8 +143,8 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
             editable={!isLoading}
             multiline
             returnKeyType="send"
-            blurOnSubmit={false}
-            onChangeText={setMessage}
+            blurOnSubmit
+            onChangeText={handleMessageChange}
             placeholderTx="chat:inputPlaceholder"
             onSubmitEditing={handleSendMessage}
             inputWrapperStyle={$inputWrapper}
@@ -145,7 +153,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
           <View style={$composerMeta}>
             <Text
               preset="formHelper"
-              text={isLoading ? "Plato is thinking…" : "Use return for a new line"}
+              text={isLoading ? "Plato is thinking…" : "Return sends the message"}
               style={$helperText}
             />
             <Text preset="formHelper" text={`${message.trim().length} chars`} style={$helperText} />

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { KeyboardAvoidingView, Platform, View } from "react-native"
 import type { TextStyle, ViewStyle } from "react-native"
 import { useUser } from "@clerk/expo"
@@ -32,6 +32,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [selectedModelId, setSelectedModelId] = useState<string>(getUserModelPreference())
+  const isSendingRef = useRef(false)
   const { user } = useUser()
 
   const sendMessage = useMutation(api.chat.sendMessage).withOptimisticUpdate(
@@ -104,7 +105,9 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const handleSendMessage = async () => {
     const trimmedMessage = message.trim()
     if (!trimmedMessage) return
+    if (isSendingRef.current) return
 
+    isSendingRef.current = true
     setIsLoading(true)
     setErrorMessage(null)
 
@@ -122,6 +125,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
       setErrorMessage(getChatErrorMessage(error, "Unable to send message. Please try again."))
     } finally {
       setIsLoading(false)
+      isSendingRef.current = false
     }
   }
 

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { View } from "react-native"
+import { KeyboardAvoidingView, Platform, View } from "react-native"
 import type { TextStyle, ViewStyle } from "react-native"
 import { useUser } from "@clerk/expo"
 import { optimisticallySendMessage } from "@convex-dev/agent/react"
@@ -43,10 +43,43 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const $flexFill: ViewStyle = { flex: 1 }
   const $invalidThreadContainer: ViewStyle = { flex: 1, gap: theme.spacing.md }
   const $composerContainer: ViewStyle = {
+    marginHorizontal: theme.spacing.md,
+    marginBottom: -theme.spacing.sm,
     paddingHorizontal: theme.spacing.md,
-    gap: theme.spacing.md,
+    paddingTop: theme.spacing.sm,
+    paddingBottom: theme.spacing.sm,
+    gap: theme.spacing.sm,
+    borderWidth: 1,
+    borderColor: theme.colors.palette.neutral300,
+    borderRadius: theme.spacing.md,
+    backgroundColor: theme.colors.palette.neutral100,
+    shadowColor: theme.colors.palette.neutral800,
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    elevation: 8,
   }
   const $row: ViewStyle = { flexDirection: "row", alignItems: "center", gap: theme.spacing.sm }
+  const $modelRow: ViewStyle = { ...$row, justifyContent: "space-between", marginBottom: 0 }
+  const $modelSelectorWrapper: ViewStyle = { flex: 1, minWidth: 0 }
+  const $sendButton: ViewStyle = { minWidth: 84, borderRadius: theme.spacing.sm }
+  const $inputWrapper: ViewStyle = {
+    borderRadius: theme.spacing.sm,
+    backgroundColor: theme.colors.palette.neutral200,
+    borderColor: errorMessage ? theme.colors.error : theme.colors.palette.neutral300,
+  }
+  const $inputStyle: TextStyle = {
+    minHeight: 48,
+    maxHeight: 120,
+    lineHeight: 22,
+  }
+  const $composerMeta: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  }
+  const $helperText: TextStyle = { color: theme.colors.textDim }
+  const $modelLabel: TextStyle = { color: theme.colors.textDim }
   const $errorText: TextStyle = {
     color: theme.colors.error,
   }
@@ -95,30 +128,51 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   return (
     <View style={$flexFill}>
       <MessageList threadId={threadId} />
-      <View style={$composerContainer}>
-        <TextField
-          value={message}
-          editable={!isLoading}
-          onChangeText={setMessage}
-          placeholderTx="chat:inputPlaceholder"
-          onSubmitEditing={handleSendMessage}
-        />
-        {errorMessage ? <Text preset="formHelper" text={errorMessage} style={$errorText} /> : null}
-        <View style={$row}>
-          <ModelSelector
-            selectedModelId={selectedModelId}
-            onModelChange={handleModelChange}
-            disabled={isLoading}
-            style={$flexFill}
+      <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined}>
+        <View style={$composerContainer}>
+          <TextField
+            value={message}
+            editable={!isLoading}
+            multiline
+            returnKeyType="send"
+            blurOnSubmit={false}
+            onChangeText={setMessage}
+            placeholderTx="chat:inputPlaceholder"
+            onSubmitEditing={handleSendMessage}
+            inputWrapperStyle={$inputWrapper}
+            style={$inputStyle}
           />
-          <Button
-            text="Send"
-            preset="small"
-            disabled={isLoading || !message.trim()}
-            onPress={handleSendMessage}
-          />
+          <View style={$composerMeta}>
+            <Text
+              preset="formHelper"
+              text={isLoading ? "Plato is thinking…" : "Use return for a new line"}
+              style={$helperText}
+            />
+            <Text preset="formHelper" text={`${message.trim().length} chars`} style={$helperText} />
+          </View>
+          {errorMessage ? (
+            <Text preset="formHelper" text={errorMessage} style={$errorText} />
+          ) : null}
+          <View style={$modelRow}>
+            <Text preset="formHelper" text="Model" style={$modelLabel} />
+            <View style={$modelSelectorWrapper}>
+              <ModelSelector
+                selectedModelId={selectedModelId}
+                onModelChange={handleModelChange}
+                disabled={isLoading}
+                style={$flexFill}
+              />
+            </View>
+            <Button
+              text={isLoading ? "Sending" : "Send"}
+              preset="small"
+              disabled={isLoading || !message.trim()}
+              style={$sendButton}
+              onPress={handleSendMessage}
+            />
+          </View>
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </View>
   )
 }

--- a/src/components/ThreadView.tsx
+++ b/src/components/ThreadView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { View } from "react-native"
-import type { ViewStyle } from "react-native"
+import type { TextStyle, ViewStyle } from "react-native"
 import { useUser } from "@clerk/expo"
 import { optimisticallySendMessage } from "@convex-dev/agent/react"
 import { useMutation } from "convex/react"
@@ -9,6 +9,7 @@ import { api } from "convex/_generated/api"
 
 import { useAppTheme } from "@/theme/context"
 import { getAnonymousUserId } from "@/utils/anonymousUser"
+import { getChatErrorMessage } from "@/utils/chatErrors"
 import {
   getEffectiveModelForThread,
   setThreadModelOverride,
@@ -28,6 +29,7 @@ interface Props {
 export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const { theme } = useAppTheme()
   const [message, setMessage] = useState<string>("")
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [selectedModelId, setSelectedModelId] = useState<string>(getUserModelPreference())
   const { user } = useUser()
@@ -45,6 +47,9 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
     gap: theme.spacing.md,
   }
   const $row: ViewStyle = { flexDirection: "row", alignItems: "center", gap: theme.spacing.sm }
+  const $errorText: TextStyle = {
+    color: theme.colors.error,
+  }
 
   useEffect(() => {
     const effectiveModel = getEffectiveModelForThread(threadId)
@@ -54,6 +59,29 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
   const handleModelChange = (modelId: string) => {
     setSelectedModelId(modelId)
     setThreadModelOverride(threadId, modelId)
+  }
+
+  const handleSendMessage = async () => {
+    if (!message.trim()) return
+
+    setIsLoading(true)
+    setErrorMessage(null)
+
+    try {
+      const anonymousUserId = isAuthenticated ? undefined : getAnonymousUserId()
+      await sendMessage({
+        threadId,
+        prompt: message,
+        modelId: selectedModelId,
+        anonymousUserId,
+      })
+      setMessage("")
+    } catch (error) {
+      console.error(error)
+      setErrorMessage(getChatErrorMessage(error, "Unable to send message. Please try again."))
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   if (!threadId || threadId === "chat" || threadId.length < 10) {
@@ -73,28 +101,9 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
           editable={!isLoading}
           onChangeText={setMessage}
           placeholderTx="chat:inputPlaceholder"
-          onSubmitEditing={async () => {
-            if (!message.trim()) return
-            setIsLoading(true)
-            try {
-              const anonymousUserId = isAuthenticated ? undefined : getAnonymousUserId()
-              await sendMessage({
-                threadId,
-                prompt: message,
-                modelId: selectedModelId,
-                anonymousUserId,
-              })
-              setMessage("")
-            } catch (error) {
-              console.error(error)
-              if (error instanceof Error && error.message.includes("rate limit")) {
-                alert(error.message)
-              }
-            } finally {
-              setIsLoading(false)
-            }
-          }}
+          onSubmitEditing={handleSendMessage}
         />
+        {errorMessage ? <Text preset="formHelper" text={errorMessage} style={$errorText} /> : null}
         <View style={$row}>
           <ModelSelector
             selectedModelId={selectedModelId}
@@ -106,27 +115,7 @@ export const ThreadView: React.FC<Props> = ({ threadId }) => {
             text="Send"
             preset="small"
             disabled={isLoading || !message.trim()}
-            onPress={async () => {
-              if (!message.trim()) return
-              setIsLoading(true)
-              try {
-                const anonymousUserId = isAuthenticated ? undefined : getAnonymousUserId()
-                await sendMessage({
-                  threadId,
-                  prompt: message,
-                  modelId: selectedModelId,
-                  anonymousUserId,
-                })
-                setMessage("")
-              } catch (error) {
-                console.error(error)
-                if (error instanceof Error && error.message.includes("rate limit")) {
-                  alert(error.message)
-                }
-              } finally {
-                setIsLoading(false)
-              }
-            }}
+            onPress={handleSendMessage}
           />
         </View>
       </View>

--- a/src/utils/chatErrors.ts
+++ b/src/utils/chatErrors.ts
@@ -1,0 +1,26 @@
+const RATE_LIMIT_MESSAGE_REGEX = /(?:AI\s+)?rate limited\. Please try again in \d+ seconds\./i
+
+function extractErrorMessage(error: unknown): string | null {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  return null
+}
+
+export function getChatErrorMessage(
+  error: unknown,
+  fallback = "Something went wrong. Please try again.",
+): string {
+  const message = extractErrorMessage(error)
+  if (!message) return fallback
+
+  const rateLimitMessage = message.match(RATE_LIMIT_MESSAGE_REGEX)?.[0]
+  if (rateLimitMessage) {
+    return rateLimitMessage.charAt(0).toUpperCase() + rateLimitMessage.slice(1)
+  }
+
+  if (message.toLowerCase().includes("rate limited")) {
+    return "You're sending messages too quickly. Please wait a moment and try again."
+  }
+
+  return message
+}

--- a/src/utils/chatErrors.ts
+++ b/src/utils/chatErrors.ts
@@ -2,6 +2,14 @@ const RATE_LIMIT_MESSAGE_REGEX = /(?:AI\s+)?rate limited\. Please try again in \
 
 function extractErrorMessage(error: unknown): string | null {
   if (error instanceof Error) return error.message
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message
+  }
   if (typeof error === "string") return error
   return null
 }


### PR DESCRIPTION
## Summary

This is one split from the current `fix-anon-users` branch. I combined the rate-limit/error-handling work with the chat UI polish because the UI refactor depends on the shared chat error helper introduced by the behavior change.

- raise anonymous daily message, thread, and AI request limits
- centralize chat error text extraction and rate-limit messaging
- show create-thread/send failures in the UI instead of dropping them silently
- refactor send handling to share submit/button behavior
- polish message cards, empty state, composer layout, loading indicators, and navigation tint

## Validation

- `bun install --frozen-lockfile` passed
- `bunx eslint convex/limiter.ts 'src/app/(home)/_layout.tsx' 'src/app/(home)/index.tsx' src/components/MessageList.tsx src/components/ThreadView.tsx src/utils/chatErrors.ts` passed
- `bun run compile` was attempted, but the project currently reports 15 TypeScript errors in files outside this PR's diff, including `src/app/(auth)/reset-password.tsx`, `src/components/ListItem.tsx`, `src/components/MessageActions.tsx`, `src/components/Screen.tsx`, locale files, and `src/screens/WelcomeScreen.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased anonymous activity limits to 20 messages/day, 5 threads/day, and 20 AI requests/day
  * Enhanced the message composer with a live character counter, model selection, and improved send UX (disabled while sending/empty)
  * Updated message list to better handle empty chats and loading more messages
* **Bug Fixes**
  * Improved chat error handling with clearer, rate-limit-aware messaging during thread creation and message sending
  * Improved mobile keyboard behavior for smoother message entry
  * Refined message display (sender labeling and updated bubble styling)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->