### PR TITLE
[codex] Refresh model catalog providers

### DIFF
--- a/convex/models.ts
+++ b/convex/models.ts
@@ -15,7 +15,7 @@ export const FREE_MODEL: ModelConfig = {
   provider: "deepseek",
   tier: "free",
   features: ["chat", "low-cost", "reasoning", "1M context"],
-  maxTokens: 384000,
+  maxTokens: 1048576,
 }
 
 export const PAID_MODELS: ModelConfig[] = [
@@ -35,7 +35,7 @@ export const PAID_MODELS: ModelConfig[] = [
     provider: "anthropic",
     tier: "pro",
     features: ["chat", "coding", "writing", "1M context"],
-    maxTokens: 64000,
+    maxTokens: 128000,
   },
   {
     id: "deepseek/deepseek-v4-pro",

--- a/convex/models.ts
+++ b/convex/models.ts
@@ -2,67 +2,58 @@ export interface ModelConfig {
   id: string
   displayName: string
   shortName: string
-  provider: "openai" | "google" | "minimax" | "microsoft"
+  provider: "openai" | "google" | "anthropic" | "deepseek"
   tier: "free" | "pro"
   features?: string[]
   maxTokens?: number
 }
 
 export const FREE_MODEL: ModelConfig = {
-  id: "google/gemini-2.0-flash-001",
-  displayName: "Gemini 2.0 Flash",
-  shortName: "Gemini 2.0",
-  provider: "google",
-  tier: "pro",
-  features: ["chat", "advanced-reasoning", "multimodal"],
-  maxTokens: 8192,
+  id: "deepseek/deepseek-v4-flash",
+  displayName: "DeepSeek V4 Flash",
+  shortName: "V4 Flash",
+  provider: "deepseek",
+  tier: "free",
+  features: ["chat", "low-cost", "reasoning", "1M context"],
+  maxTokens: 384000,
 }
 
 export const PAID_MODELS: ModelConfig[] = [
   {
-    id: "minimax/minimax-m2.5:free",
-    displayName: "MiniMax M2.5",
-    shortName: "M2.5",
-    provider: "minimax",
-    tier: "free",
-    features: ["chat", "improved-reasoning"],
-    maxTokens: 8192,
+    id: "google/gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
+    shortName: "Gemini 3.5",
+    provider: "google",
+    tier: "pro",
+    features: ["chat", "reasoning", "multimodal", "1M context"],
+    maxTokens: 65536,
   },
   {
-    id: "microsoft/phi-4-mini-instruct",
-    displayName: "Phi 4 Mini",
-    shortName: "Phi 4 Mini",
-    provider: "microsoft",
+    id: "anthropic/claude-sonnet-4.6",
+    displayName: "Claude Sonnet 4.6",
+    shortName: "Sonnet 4.6",
+    provider: "anthropic",
     tier: "pro",
-    features: ["chat", "fast-response"],
+    features: ["chat", "coding", "writing", "1M context"],
+    maxTokens: 64000,
+  },
+  {
+    id: "deepseek/deepseek-v4-pro",
+    displayName: "DeepSeek V4 Pro",
+    shortName: "V4 Pro",
+    provider: "deepseek",
+    tier: "pro",
+    features: ["chat", "deep reasoning", "coding", "1M context"],
+    maxTokens: 384000,
+  },
+  {
+    id: "openai/gpt-5.4-mini",
+    displayName: "GPT-5.4 Mini",
+    shortName: "GPT-5.4 Mini",
+    provider: "openai",
+    tier: "pro",
+    features: ["chat", "reasoning", "coding", "tool use"],
     maxTokens: 128000,
-  },
-  {
-    id: "openai/gpt-oss-20b",
-    displayName: "GPT-OSS 20B",
-    shortName: "OSS 20B",
-    provider: "openai",
-    tier: "free",
-    features: ["chat", "fast-response"],
-    maxTokens: 32000,
-  },
-  {
-    id: "openai/gpt-oss-safeguard-20b",
-    displayName: "GPT-OSS Safeguard 20B",
-    shortName: "OSS Safeguard 20B",
-    provider: "openai",
-    tier: "pro",
-    features: ["chat", "fast-response"],
-    maxTokens: 65000,
-  },
-  {
-    id: "openai/gpt-oss-120b",
-    displayName: "GPT-OSS 120B",
-    shortName: "OSS 120B",
-    provider: "openai",
-    tier: "pro",
-    features: ["chat"],
-    maxTokens: 32000,
   },
 ]
 

--- a/convex/models.ts
+++ b/convex/models.ts
@@ -15,7 +15,7 @@ export const FREE_MODEL: ModelConfig = {
   provider: "deepseek",
   tier: "free",
   features: ["chat", "low-cost", "reasoning", "1M context"],
-  maxTokens: 1048576,
+  maxTokens: 65536,
 }
 
 export const PAID_MODELS: ModelConfig[] = [


### PR DESCRIPTION
## Summary

This is one split from the current `fix-anon-users` branch. It isolates the model catalog/provider changes so they can be reviewed independently from build and chat UI work.

- replace the free model with DeepSeek V4 Flash
- update supported provider types to include Anthropic and DeepSeek
- refresh the paid model list with Gemini, Claude, DeepSeek, and GPT options
- keep model validation/default behavior unchanged around the configured catalog

## Validation

- `bun install --frozen-lockfile` passed
- `bunx eslint convex/models.ts` passed
- `bun run compile` was attempted, but the project currently reports 15 TypeScript errors in files outside this PR's diff, including `src/app/(auth)/reset-password.tsx`, `src/components/ListItem.tsx`, `src/components/MessageActions.tsx`, `src/components/Screen.tsx`, locale files, and `src/screens/WelcomeScreen.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded the free tier model to **Deepseek v4 Flash**, with improved performance and expanded feature coverage at no cost
  * Refreshed the paid model catalog to a curated set from **OpenAI, Google, Anthropic, and Deepseek** (removing prior legacy offerings)
  * Limited supported model providers to **OpenAI, Google, Anthropic, and Deepseek** to streamline selection and improve reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->